### PR TITLE
Updated apk discovery and added extraction script

### DIFF
--- a/extract_files.sh
+++ b/extract_files.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# List of files to be extracted
+declare -a files=(
+"data.ext4.win001"
+"data.ext4.win002"
+"data.ext4.win003"
+)
+
+for f in ${files[*]}
+do
+    tar -xvf $f
+done
+

--- a/load_packages.sh
+++ b/load_packages.sh
@@ -51,7 +51,7 @@ do
     adb shell pm clear $package
     
     printf "Reinstalling apk of %s\n" $package
-    apkpath=$localapkpath/$(ls -1 "$localapkpath" | grep -i $package)
+    apkpath=$(find . -maxdepth 4 -type d -print | grep $package | head -n1)
     adb install -r "$apkpath/base.apk"
     
     printf "Restoring %s\n" $package


### PR DESCRIPTION
The command used to find apkpath is incompatible with the recent versions of Android. I have updated the command find the appropriate path. I have also added an extraction script.

The old command searches for a folder inside "data/app" that has $package as a substring in its name, however the new folder structure is as follows:
`data/app/<random string>/com.android.vending-<random string>`